### PR TITLE
Add OpenSearch MCP notebook

### DIFF
--- a/mcp-protocol/opensearch_mcp_server.ipynb
+++ b/mcp-protocol/opensearch_mcp_server.ipynb
@@ -5,15 +5,97 @@
    "id": "a4d6cc2c",
    "metadata": {},
    "source": [
-    "# OpenSearch MCP Server"
+    "# OpenSearch MCP Server with Strands Agents"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b2d9bd47",
+   "id": "f6b03617-3b79-4752-8201-98dc8474ee37",
    "metadata": {},
    "source": [
-    "This notebook demonstrates how to set up and use OpenSearch MCP server in both stdio and SSE modes, including server configuration and tool execution. For complete documentation, see [opensearch-mcp-server-py](https://github.com/opensearch-project/opensearch-mcp-server-py) repository."
+    "This notebook demonstrates how to set up and use OpenSearch MCP server in stdio and streaming (SSE/Streamable HTTP) protocols with Strands Agents, including server configuration and tool execution. For complete documentation, see [opensearch-mcp-server-py](https://github.com/opensearch-project/opensearch-mcp-server-py) repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ee489a9-8fc6-4d04-886b-abd6f87903a7",
+   "metadata": {},
+   "source": [
+    "## Table of Contents"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "389e8713-d814-4a5f-b6a9-12f72dc24646",
+   "metadata": {},
+   "source": [
+    "- [Prerequisites](#Prerequisites)\n",
+    "- Basic Setup\n",
+    "  1. [Standard I/O (stdio) Server](#Standard-I/O-(stdio)-Server)\n",
+    "  2. [Streamable HTTP](#Streamable-HTTP)\n",
+    "  3. [Server-Sent Events (SSE)](#Server-Sent-Events-(SSE))\n",
+    "- Advanced Features\n",
+    "  - [Multi-cluster Support](#Multi-cluster-Support)\n",
+    "  - [Tool Filter](#Tool-Filter)\n",
+    "- [Clean Up](#Clean-Up)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34474119-b99e-4110-b72e-cd71a3b58343",
+   "metadata": {},
+   "source": [
+    "## Prerequisites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24ae4373-e8bb-4b9c-a487-e7ee92a74607",
+   "metadata": {},
+   "source": [
+    "### 1. Install required packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7493ac9d-3b24-4e33-8655-fe6c00d8fdde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install strands-agents --quiet\n",
+    "%pip install strands-agents-tools --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6f6bfb3-293c-48d8-acb4-218bf8075ec4",
+   "metadata": {},
+   "source": [
+    "### 2. Configure AWS credentials for Amazon Bedrock model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6a664ec-5c87-4007-8f13-5c32b0055c94",
+   "metadata": {},
+   "source": [
+    "Strands Agents supports many different model providers. In this notebook, we'll be using the default Amazon Bedrock model provider with Claude 3.7 model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6df87c42-6dac-48af-abfa-7d077c571704",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['AWS_REGION'] = \"<your_aws_region>\"\n",
+    "os.environ['AWS_ACCESS_KEY_ID'] = \"<your_aws_access_key>\"\n",
+    "os.environ['AWS_SECRET_ACCESS_KEY'] = \"<your_aws_secret_access_key>\"\n",
+    "os.environ['AWS_SESSION_TOKEN'] = \"<your_aws_session_token>\"  # optional"
    ]
   },
   {
@@ -21,51 +103,62 @@
    "id": "ec8bcc9f",
    "metadata": {},
    "source": [
-    "## Stdio Server"
+    "## Standard I/O (stdio) Server"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4e97e01d",
+   "id": "f44744a5-94e8-434c-8be6-f5e8d08ebebb",
    "metadata": {},
    "source": [
-    "Configure MCP server with `stdio` protocol using the sample below. This configuration works with both [Claude Desktop](https://modelcontextprotocol.io/quickstart/user) and [Q Developer CLI](https://github.com/aws/amazon-q-developer-cli). For more detailed information, see the OpenSearch MCP server [user guide](https://github.com/opensearch-project/opensearch-mcp-server-py/blob/main/USER_GUIDE.md#quick-start)."
+    "Configure OpenSearch MCP server with `stdio` protocol and interact with the agent using the code below. Type `/quit` to exit."
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "78e9b482",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39c18413",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "```json\n",
-    "{\n",
-    "    \"mcpServers\": {\n",
-    "        \"opensearch-mcp-server\": {\n",
-    "            \"command\": \"uvx\",\n",
-    "            \"args\": [\n",
-    "                \"opensearch_mcp_server_py\"\n",
-    "            ],\n",
-    "            \"env\": {\n",
-    "                // Optional\n",
-    "                \"OPENSEARCH_URL\": \"<your_opensearch_domain_url>\",\n",
-    "                \n",
-    "                // For OpenSearch Serverless\n",
-    "                \"AWS_OPENSEARCH_SERVERLESS\": \"true\",  // Set to \"true\" for OpenSearch Serverless\n",
+    "from mcp import stdio_client, StdioServerParameters\n",
+    "from strands import Agent\n",
+    "from strands.tools.mcp import MCPClient\n",
     "\n",
-    "                // For Basic Authentication\n",
-    "                \"OPENSEARCH_USERNAME\": \"<your_opensearch_domain_username>\",\n",
-    "                \"OPENSEARCH_PASSWORD\": \"<your_opensearch_domain_password>\",\n",
-    "\n",
-    "                // For IAM Role Authentication\n",
-    "                \"AWS_REGION\": \"<your_aws_region>\",\n",
-    "                \"AWS_ACCESS_KEY_ID\": \"<your_aws_access_key>\",\n",
-    "                \"AWS_SECRET_ACCESS_KEY\": \"<your_aws_secret_access_key>\",\n",
-    "                \"AWS_SESSION_TOKEN\": \"<your_aws_session_token>\"\n",
-    "            }\n",
+    "# Connect to an OpenSearch MCP server using stdio transport\n",
+    "stdio_mcp_client = MCPClient(lambda: stdio_client(\n",
+    "    StdioServerParameters(\n",
+    "        command=\"uvx\", \n",
+    "        args=[\"opensearch-mcp-server-py\"],\n",
+    "        env={\n",
+    "            \"OPENSEARCH_URL\": \"<your_opensearch_domain_url>\",\n",
+    "            \"OPENSEARCH_USERNAME\": \"<your_opensearch_domain_username>\",\n",
+    "            \"OPENSEARCH_PASSWORD\": \"<your_opensearch_domain_password>\",\n",
     "        }\n",
-    "    }\n",
-    "}\n",
-    "```"
+    "    )\n",
+    "))\n",
+    "\n",
+    "# Create an agent with MCP tools\n",
+    "with stdio_mcp_client:\n",
+    "    # Get the tools from the MCP server\n",
+    "    tools = stdio_mcp_client.list_tools_sync()\n",
+    "\n",
+    "    # Create an agent with these tools\n",
+    "    agent = Agent(tools=tools)\n",
+    "\n",
+    "    while True:\n",
+    "        try:\n",
+    "            user_input = input(\"\\n> \")\n",
+    "            if user_input == \"/quit\":\n",
+    "                break\n",
+    "            agent(user_input)\n",
+    "\n",
+    "        except KeyboardInterrupt:\n",
+    "            print(\"\\n\\nExecution interrupted. Exiting...\")\n",
+    "            break\n",
+    "        except Exception as e:\n",
+    "            print(f\"\\nAn error occurred: {str(e)}\")\n",
+    "            print(\"Please try a different request.\")"
    ]
   },
   {
@@ -73,15 +166,15 @@
    "id": "fa7d48b2",
    "metadata": {},
    "source": [
-    "## SSE Server"
+    "## Streamable HTTP"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "39ef6932-8211-4671-9e4a-94b1ca167ab5",
+   "id": "752a9886",
    "metadata": {},
    "source": [
-    "Follow these steps to set up MCP server with `sse` protocol using OpenSearch MCP client:"
+    "Follow these steps to setup OpenSearch MCP server with `streamable HTTP` protocol:"
    ]
   },
   {
@@ -107,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install opensearch-mcp-server-py"
+    "%pip install opensearch-mcp-server-py --quiet"
    ]
   },
   {
@@ -128,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "293b06d7",
+   "id": "508f233a-3e7f-4ec8-ba11-601ee7b2ce8c",
    "metadata": {},
    "source": [
     "#### a. Basic Authentication"
@@ -212,7 +305,7 @@
    "source": [
     "By default, the server will run on port **9900**. You can change the port number by specifying the port number in below command, for example:\n",
     "\n",
-    "`[\"python\", \"-m\", \"mcp_server_opensearch\", \"--transport\", \"sse\", \"--port\", \"<your_desired_port_number>\"]`"
+    "`[\"python\", \"-m\", \"mcp_server_opensearch\", \"--transport\", \"stream\", \"--port\", \"<your_desired_port_number>\"]`"
    ]
   },
   {
@@ -224,7 +317,7 @@
    "source": [
     "import subprocess\n",
     "process = subprocess.Popen(\n",
-    "    [\"python\", \"-m\", \"mcp_server_opensearch\", \"--transport\", \"sse\"],\n",
+    "    [\"python\", \"-m\", \"mcp_server_opensearch\", \"--transport\", \"stream\"],\n",
     "    stdout=subprocess.PIPE,\n",
     "    stderr=subprocess.PIPE\n",
     ")"
@@ -240,247 +333,483 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e87843ec",
+   "id": "ded9f358",
    "metadata": {},
    "source": [
-    "### 4. Create an MCP connector"
+    "### 4. Configure Strands Agents"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "db31492a",
+   "id": "048aaa63-c233-429a-a433-8d6d1e06a505",
    "metadata": {},
    "source": [
-    "An MCP connector stores connection details and credentials for your MCP server."
+    "Configure OpenSearch MCP server with `streamable HTTP` protocol and interact with the agent using the code below. Type `/quit` to exit."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1fdf1523",
+   "id": "0a0a92b0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import requests\n",
-    "from requests.auth import HTTPBasicAuth\n",
+    "from mcp.client.streamable_http import streamablehttp_client\n",
+    "from strands import Agent\n",
+    "from strands.tools.mcp.mcp_client import MCPClient\n",
     "\n",
-    "# Change these variables with your OpenSearch and MCP server information\n",
-    "opensearch_domain_url = \"<your_opensearch_domain_url>\"\n",
-    "opensearch_domain_username = \"<your_opensearch_domain_username>\"\n",
-    "opensearch_domain_password = \"<your opensearch_domain_password\"\n",
-    "mcp_server_url = \"<your_mcp_server_url>\"  # For example \"http://localhost:9900\"\n",
-    "mcp_server_api_key = \"<your_mcp_server_api_key>\"  # For example \"secret-token\"\n",
+    "streamable_http_mcp_client = MCPClient(lambda: streamablehttp_client(\"http://localhost:9900/mcp\"))\n",
     "\n",
-    "# Configure settings needed to enable MCP protocol\n",
-    "payload = {\n",
-    "  \"persistent\": {\n",
-    "    \"plugins.ml_commons.trusted_connector_endpoints_regex\": [\n",
-    "        mcp_server_url,\n",
-    "        \"https://api.openai.com/v1/chat/completions\"\n",
-    "    ],\n",
-    "    \"plugins.ml_commons.mcp_connector_enabled\": \"true\"\n",
-    "  }\n",
-    "}\n",
-    "settings_response = requests.put(f'{opensearch_domain_url}/_cluster/settings',\n",
-    "                        auth=HTTPBasicAuth(opensearch_domain_username, opensearch_domain_password),\n",
-    "                        json=payload,\n",
-    "                        headers={\"Content-Type\": \"application/json\"})\n",
-    "print(settings_response.text)\n",
+    "# Create an agent with MCP tools\n",
+    "with streamable_http_mcp_client:\n",
+    "    # Get the tools from the MCP server\n",
+    "    tools = streamable_http_mcp_client.list_tools_sync()\n",
     "\n",
-    "# Create an MCP connector\n",
-    "payload = {\n",
-    "    \"name\": \"My MCP Connector\",\n",
-    "    \"description\": \"Connects to the OpenSearch MCP server\",\n",
-    "    \"version\": 1,\n",
-    "    \"protocol\": \"mcp_sse\",\n",
-    "    \"url\": mcp_server_url,\n",
-    "    \"credential\": {\n",
-    "        \"mcp_server_key\": mcp_server_api_key\n",
-    "    },\n",
-    "    \"headers\": {\n",
-    "        \"Authorization\": \"Bearer ${credential.mcp_server_key}\"\n",
-    "    }\n",
-    "}\n",
-    "connector_response = requests.post(f'{opensearch_domain_url}/_plugins/_ml/connectors/_create',\n",
-    "                        auth=HTTPBasicAuth(opensearch_domain_username, opensearch_domain_password),\n",
-    "                        json=payload,\n",
-    "                        headers={\"Content-Type\": \"application/json\"})\n",
-    "print(connector_response.text)"
+    "    # Create an agent with these tools\n",
+    "    agent = Agent(tools=tools)\n",
+    "\n",
+    "    while True:\n",
+    "        try:\n",
+    "            user_input = input(\"\\n> \")\n",
+    "            if user_input == \"/quit\":\n",
+    "                break\n",
+    "            agent(user_input)\n",
+    "\n",
+    "        except KeyboardInterrupt:\n",
+    "            print(\"\\n\\nExecution interrupted. Exiting...\")\n",
+    "            break\n",
+    "        except Exception as e:\n",
+    "            print(f\"\\nAn error occurred: {str(e)}\")\n",
+    "            print(\"Please try a different request.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b739bf62",
+   "id": "3a4ae5ee-7652-4f61-a622-e837b81bc8f2",
    "metadata": {},
    "source": [
-    "### 5. Register a remote model"
+    "## Server-Sent Events (SSE)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f240cca4",
+   "id": "f1fd9f4d-da39-46ea-8590-c0e37bc1e410",
    "metadata": {},
    "source": [
-    "Register any externally hosted large language model (LLM) using a connector. For a list of supported models, see [Supported connectors](https://docs.opensearch.org/docs/latest/ml-commons-plugin/remote-models/supported-connectors/).\n",
-    "\n",
-    "In this notebook, we're using OpenAI chat model, but you can register any model."
+    "Complete the steps (1-3) from Streamable HTTP section, then configure OpenSearch MCP server with `sse` protocol and interact with the agent using the code below. Type `/quit` to exit."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adee6c56",
+   "id": "59590dad-4f29-4b77-a058-288111f5d6d4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Change this variable with your model API key\n",
-    "openai_api_key = \"<your_openai_api_key>\"\n",
+    "from mcp.client.sse import sse_client\n",
+    "from strands import Agent\n",
+    "from strands.tools.mcp import MCPClient\n",
     "\n",
-    "# Create OpenAI chat model\n",
-    "payload = {\n",
-    "    \"name\": \"My OpenAI model: gpt-4\",\n",
-    "    \"function_name\": \"remote\",\n",
-    "    \"description\": \"Test model registration\",\n",
-    "    \"connector\": {\n",
-    "        \"name\": \"My OpenAI Connector: gpt-4\",\n",
-    "        \"description\": \"Connector for the OpenAI chat model\",\n",
-    "        \"version\": 1,\n",
-    "        \"protocol\": \"http\",\n",
-    "        \"parameters\": {\n",
-    "            \"model\": \"gpt-4o\"\n",
-    "        },\n",
-    "        \"credential\": {\n",
-    "            \"openAI_key\": openai_api_key\n",
-    "        },\n",
-    "        \"actions\": [{\n",
-    "            \"action_type\": \"predict\",\n",
-    "            \"method\": \"POST\",\n",
-    "            \"url\": \"https://api.openai.com/v1/chat/completions\",\n",
-    "            \"headers\": {\n",
-    "                \"Authorization\": \"Bearer ${credential.openAI_key}\"\n",
-    "            },\n",
-    "            \"request_body\": \"{ \\\"model\\\": \\\"${parameters.model}\\\", \\\"messages\\\": [{\\\"role\\\":\\\"developer\\\",\\\"content\\\":\\\"${parameters.system_instruction}\\\"},${parameters._chat_history:-}{\\\"role\\\":\\\"user\\\",\\\"content\\\":\\\"${parameters.prompt}\\\"}${parameters._interactions:-}], \\\"tools\\\": [${parameters._tools:-}],\\\"parallel_tool_calls\\\":${parameters.parallel_tool_calls},\\\"tool_choice\\\": \\\"${parameters.tool_choice}\\\" }\"\n",
-    "        }]\n",
-    "    }\n",
-    "}\n",
-    "response = requests.post(f'{opensearch_domain_url}/_plugins/_ml/models/_register',\n",
-    "                        auth=HTTPBasicAuth(opensearch_domain_username, opensearch_domain_password),\n",
-    "                        json=payload,\n",
-    "                        headers={\"Content-Type\": \"application/json\"})\n",
-    "print(response.text)"
+    "# Connect to an MCP server using SSE transport\n",
+    "sse_mcp_client = MCPClient(lambda: sse_client(\"http://localhost:9900/sse\"))\n",
+    "\n",
+    "# Create an agent with MCP tools\n",
+    "with sse_mcp_client:\n",
+    "    # Get the tools from the MCP server\n",
+    "    tools = sse_mcp_client.list_tools_sync()\n",
+    "\n",
+    "    # Create an agent with these tools\n",
+    "    agent = Agent(tools=tools)\n",
+    "\n",
+    "    while True:\n",
+    "        try:\n",
+    "            user_input = input(\"\\n> \")\n",
+    "            if user_input == \"/quit\":\n",
+    "                break\n",
+    "            agent(user_input)\n",
+    "\n",
+    "        except KeyboardInterrupt:\n",
+    "            print(\"\\n\\nExecution interrupted. Exiting...\")\n",
+    "            break\n",
+    "        except Exception as e:\n",
+    "            print(f\"\\nAn error occurred: {str(e)}\")\n",
+    "            print(\"Please try a different request.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bd4666ec",
+   "id": "fe59961b-1883-4846-8ac5-c0f3198607f5",
    "metadata": {},
    "source": [
-    "### 6. Register an agent for accessing MCP tools"
+    "## Multi-cluster Support"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "339141ce",
+   "id": "a6e12e95-08fa-4769-b116-cb4a381806f8",
    "metadata": {},
    "source": [
-    "Currently, MCP tools can only be used with [conversational](https://docs.opensearch.org/docs/latest/ml-commons-plugin/agents-tools/agents/conversational/) or [plan-execute-reflect](https://docs.opensearch.org/docs/latest/ml-commons-plugin/agents-tools/agents/plan-execute-reflect/) agent types.\n",
-    "\n",
-    "In this notebook, we'll use conversational agent."
+    "OpenSearch MCP server operates in either `single` (default) or `multi` model. Whiel single model connects to one cluster, multi model enables connections to multiple clusters. For more detailed information, see [Server Modes](https://github.com/opensearch-project/opensearch-mcp-server-py/blob/main/USER_GUIDE.md#server-modes)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d25f8b60-dce7-4c8b-a3fd-330938c1e1e9",
+   "metadata": {},
+   "source": [
+    "Follow these steps to configure an OpenSearch MCP server with multi-cluster support:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af2eea6c-4e22-4c1f-b3d6-0b886e1bd656",
+   "metadata": {},
+   "source": [
+    "### 1. Configure a YAML file with clusters information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4a88759-548c-4eb6-8206-e3506589c2f8",
+   "metadata": {},
+   "source": [
+    "This code creates a local `config.yml` file. You can skip this step and use your existing config file or see [example_clusters.yml](https://github.com/opensearch-project/opensearch-mcp-server-py/blob/main/example_clusters.yml) for more configuration examples."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c4eadd5",
+   "id": "3fe6f3fd-3612-47c2-9319-19c04e42c2e5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Change these variables with the connector ID and model ID from previous steps\n",
-    "mcp_connector_id = \"<your_mcp_connector_id>\"  # From step 4\n",
-    "llm_model_id = \"<your_llm_model_id>\"  # From step 5\n",
+    "# Create config file\n",
+    "config = \"\"\"\n",
+    "version: \"1.0\"\n",
+    "description: \"OpenSearch cluster configurations\"\n",
     "\n",
-    "# Register a conversational agent\n",
-    "payload = {\n",
-    "    \"name\": \"OpenSearch MCP server\",\n",
-    "    \"type\": \"conversational\",\n",
-    "    \"description\": \"Uses MCP to information related to OpenSearch\",\n",
-    "    \"llm\": {\n",
-    "        \"model_id\": llm_model_id,\n",
-    "        \"parameters\": {\n",
-    "            \"max_iteration\": 5,\n",
-    "            \"system_instruction\": \"You are a helpful assistant.\",\n",
-    "            \"prompt\": \"${parameters.question}\"\n",
+    "clusters:\n",
+    "  local-cluster:\n",
+    "    opensearch_url: \"<your_local_cluster_url>\"\n",
+    "    opensearch_username: \"<your_local_cluster_username>\"\n",
+    "    opensearch_password: \"<your_local_cluster_password>\"\n",
+    "\n",
+    "  remote-cluster:\n",
+    "    opensearch_url: \"<your_remote_cluster_url>\"\n",
+    "    opensearch_username: \"<your_remote_cluster_username>\"\n",
+    "    opensearch_password: \"<your_remote_cluster_password\"\n",
+    "\"\"\"\n",
+    "\n",
+    "# Write to file\n",
+    "with open('config.yml', 'w') as f:\n",
+    "    f.write(config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da3542e4-55c5-4612-9900-7717104393a4",
+   "metadata": {},
+   "source": [
+    "### 2. Start the server in `multi` mode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09b76aa4-08fe-4ec5-9465-9455d603b5b8",
+   "metadata": {},
+   "source": [
+    "Configure OpenSearch MCP server with `stdio` protocol in `multi` mode and interact with the agent using the code below. Type `/quit` to exit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02c973cf-9c44-419b-baf6-b7aab473ee4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mcp import stdio_client, StdioServerParameters\n",
+    "from strands import Agent\n",
+    "from strands.tools.mcp import MCPClient\n",
+    "\n",
+    "# Connect to an OpenSearch MCP server using stdio transport in multi mode\n",
+    "stdio_mcp_client = MCPClient(lambda: stdio_client(\n",
+    "    StdioServerParameters(\n",
+    "        command=\"uvx\", \n",
+    "        args=[\n",
+    "            \"opensearch-mcp-server-py\",\n",
+    "            \"--mode\", \"multi\",\n",
+    "            \"--config\", \"config.yml\"\n",
+    "        ]\n",
+    "    )\n",
+    "))\n",
+    "\n",
+    "# Create an agent with MCP tools\n",
+    "with stdio_mcp_client:\n",
+    "    # Get the tools from the MCP server\n",
+    "    tools = stdio_mcp_client.list_tools_sync()\n",
+    "\n",
+    "    # Create an agent with these tools\n",
+    "    agent = Agent(tools=tools)\n",
+    "\n",
+    "    while True:\n",
+    "        try:\n",
+    "            user_input = input(\"\\n> \")\n",
+    "            if user_input == \"/quit\":\n",
+    "                break\n",
+    "            agent(user_input)\n",
+    "\n",
+    "        except KeyboardInterrupt:\n",
+    "            print(\"\\n\\nExecution interrupted. Exiting...\")\n",
+    "            break\n",
+    "        except Exception as e:\n",
+    "            print(f\"\\nAn error occurred: {str(e)}\")\n",
+    "            print(\"Please try a different request.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7a14b1a-1dc7-4fd9-b624-671cd817d312",
+   "metadata": {},
+   "source": [
+    "Start the server with `streamable HTTP` or `SSE` protocol in `multi` mode:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8aa71f9-7f56-4eee-aa16-8f7af6adb2e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "process = subprocess.Popen(\n",
+    "    [\"python\", \"-m\", \"mcp_server_opensearch\", \"--mode\", \"multi\", \"--config\", \"config.yml\", \"--transport\", \"stream\"],\n",
+    "    stdout=subprocess.PIPE,\n",
+    "    stderr=subprocess.PIPE\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b1f2c96-f5a8-4f1d-8a42-a0ae008e7950",
+   "metadata": {},
+   "source": [
+    "Then, use the same agent interaction code as shown in the [Streamable HTTP](#Streamable-HTTP) or [Server-Sent Events (SSE)](#Server-Sent-Events-(SSE)) section above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "751a0ab5-ea63-4dc6-ba84-d6df0d6cf1ac",
+   "metadata": {},
+   "source": [
+    "## Tool Filter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5ac65c5-8087-4c7a-bcc8-2b08ad39e107",
+   "metadata": {},
+   "source": [
+    "OpenSearch MCP server supports tool filtering feature where you can disable specific tools by name, category, or operation type. This can be configured using either a YAML configuration file or environment variables. In this notebook, we will use the YAML file approach. For more detailed information, see [Tool Filter](https://github.com/opensearch-project/opensearch-mcp-server-py/blob/main/USER_GUIDE.md#tool-filter)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fb4dc06-0aee-4e67-baa2-836942d398b2",
+   "metadata": {},
+   "source": [
+    "Follow these steps to configure an OpenSearch MCP server with tool filter:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbd8d516-c394-4dee-a672-b372fb6c3d33",
+   "metadata": {},
+   "source": [
+    "### 1. Configure a YAML file with tool filter configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ad4a064-27a7-4459-87af-af5676728771",
+   "metadata": {},
+   "source": [
+    "This example creates a `non-critical` category of tools that will be disabled. Customize the categories and filters based on your requirements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82f840e2-133c-4658-86af-03eb049f3888",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create config file\n",
+    "config = \"\"\"\n",
+    "tool_category:\n",
+    "  non-critical:\n",
+    "    - ExplainTool\n",
+    "    - CountTool\n",
+    "\n",
+    "tool_filters:\n",
+    "  disabled_categories:\n",
+    "    - non-critical\n",
+    "\"\"\"\n",
+    "\n",
+    "# Write to file\n",
+    "with open('config.yml', 'w') as f:\n",
+    "    f.write(config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4611ee2-c7a6-473e-8ced-5a5aef3b9252",
+   "metadata": {},
+   "source": [
+    "### 2. Start the server with tool filter configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f654773a-cd59-4f52-b1bc-58963882714f",
+   "metadata": {},
+   "source": [
+    "Configure OpenSearch MCP server with `stdio` protocol with tool filtering enabled. The agent will only have access to non-disabled tools. Type `/quit` to exit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6e3f0ef-5a24-482c-aac9-5a84f81984df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mcp import stdio_client, StdioServerParameters\n",
+    "from strands import Agent\n",
+    "from strands.tools.mcp import MCPClient\n",
+    "\n",
+    "# Connect to an OpenSearch MCP server using stdio transport with tool filter configuration file\n",
+    "stdio_mcp_client = MCPClient(lambda: stdio_client(\n",
+    "    StdioServerParameters(\n",
+    "        command=\"uvx\", \n",
+    "        args=[\n",
+    "            \"opensearch-mcp-server-py\",\n",
+    "            \"--config\", \"config.yml\"\n",
+    "        ],\n",
+    "        env={\n",
+    "            \"OPENSEARCH_URL\": \"<your_opensearch_domain_url>\",\n",
+    "            \"OPENSEARCH_USERNAME\": \"<your_opensearch_domain_username>\",\n",
+    "            \"OPENSEARCH_PASSWORD\": \"<your_opensearch_domain_password>\"\n",
     "        }\n",
-    "    },\n",
-    "    \"memory\": {\n",
-    "        \"type\": \"conversation_index\"\n",
-    "    },\n",
-    "    \"parameters\": {\n",
-    "        \"_llm_interface\": \"openai/v1/chat/completions\",\n",
-    "        \"mcp_connectors\": [{\n",
-    "            \"mcp_connector_id\": mcp_connector_id\n",
-    "        }]\n",
-    "    },\n",
-    "    \"app_type\": \"os_chat\"\n",
-    "}\n",
-    "response = requests.post(f'{opensearch_domain_url}/_plugins/_ml/agents/_register',\n",
-    "                        auth=HTTPBasicAuth(opensearch_domain_username, opensearch_domain_password),\n",
-    "                        json=payload,\n",
-    "                        headers={\"Content-Type\": \"application/json\"})\n",
-    "print(response.text)"
+    "    )\n",
+    "))\n",
+    "\n",
+    "# Create an agent with MCP tools\n",
+    "with stdio_mcp_client:\n",
+    "    # Get the tools from the MCP server\n",
+    "    tools = stdio_mcp_client.list_tools_sync()\n",
+    "\n",
+    "    # Create an agent with these tools\n",
+    "    agent = Agent(tools=tools)\n",
+    "\n",
+    "    while True:\n",
+    "        try:\n",
+    "            user_input = input(\"\\n> \")\n",
+    "            if user_input == \"/quit\":\n",
+    "                break\n",
+    "            agent(user_input)\n",
+    "\n",
+    "        except KeyboardInterrupt:\n",
+    "            print(\"\\n\\nExecution interrupted. Exiting...\")\n",
+    "            break\n",
+    "        except Exception as e:\n",
+    "            print(f\"\\nAn error occurred: {str(e)}\")\n",
+    "            print(\"Please try a different request.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8900e338",
+   "id": "1ce8332c-128c-47e4-b23d-537456e25929",
    "metadata": {},
    "source": [
-    "### 7. Execute the agent"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2a2710c5-d32c-4ecf-811d-44743ac50746",
-   "metadata": {},
-   "source": [
-    "Example questions you can ask the agent about OpenSearch:\n",
-    "- `ListIndexTool` : List all indices in my OpenSearch cluster?\n",
-    "- `GetShardsTool` : Can you get the shards information of an index called .plugins-ml-config in my OpenSearch cluster?\n",
-    "- `ClusterHealthTool` : Can you check my OpenSearch cluster health?\n",
-    "- `SearchIndexTool` : I have an index called sample_data_ecommerce, can you show me the email addresses of 20 customers from this index?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "505863b5-8290-4016-8f53-f9d602ae04ce",
-   "metadata": {},
-   "source": [
-    "> See more available tools in [OpenSearch MCP server](https://github.com/opensearch-project/opensearch-mcp-server-py/blob/main/README.md#available-tools) repository. "
+    "Start the server with `streamable HTTP` or `SSE` protocol, specifying the tool configuration file:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a4b091a",
+   "id": "f9dc7216-a9ab-4bc7-9b58-81cc5b08715d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Change these variables with the agent ID from previous step and the question for the agent\n",
-    "agent_id = \"<your_agent_id>\"  # From step 6\n",
-    "question = \"<your_question>\"\n",
+    "import subprocess\n",
+    "process = subprocess.Popen(\n",
+    "    [\"python\", \"-m\", \"mcp_server_opensearch\", \"--config\", \"config.yml\", \"--transport\", \"stream\"],\n",
+    "    stdout=subprocess.PIPE,\n",
+    "    stderr=subprocess.PIPE\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6409b1c-b3e6-4256-95a8-fa04b5666ae6",
+   "metadata": {},
+   "source": [
+    "Then, use the same agent interaction code as shown in the [Streamable HTTP](#Streamable-HTTP) or [Server-Sent Events (SSE)](#Server-Sent-Events-(SSE)) section above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ee2b6ac-65f5-4516-b602-2710791549b5",
+   "metadata": {},
+   "source": [
+    "## Clean Up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "817834a4-40b8-421c-9a7e-4655a5a5f86b",
+   "metadata": {},
+   "source": [
+    "### Stop server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a9c3c33-7350-4fd4-964d-775b6f53323b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Graceful termination\n",
+    "process.terminate()\n",
+    "process.wait()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f3cd5ab-8b66-476d-81c2-a7d4931c9a9d",
+   "metadata": {},
+   "source": [
+    "### Remove configuration file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a5d6965-f9b2-4839-b8a5-95bd54e749d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up config file\n",
+    "import os\n",
     "\n",
-    "# Execute the agent\n",
-    "payload = {\n",
-    "  \"parameters\": {\n",
-    "    \"question\": question,\n",
-    "    \"verbose\": True\n",
-    "  }\n",
-    "}\n",
-    "response = requests.post(f'{opensearch_domain_url}/_plugins/_ml/agents/{agent_id}/_execute',\n",
-    "                        auth=HTTPBasicAuth(opensearch_domain_username, opensearch_domain_password),\n",
-    "                        json=payload,\n",
-    "                        headers={\"Content-Type\": \"application/json\"})\n",
-    "print(response.text)"
+    "try:\n",
+    "    os.remove('config.yml')\n",
+    "    print(\"Config file removed successfully\")\n",
+    "except FileNotFoundError:\n",
+    "    print(\"Config file already removed\")"
    ]
   }
  ],


### PR DESCRIPTION
*Description of changes:*
Add notebook to setup OpenSearch MCP server and do tool execution with Strands Agents.

Might be hard to see the difference, easier way to see the notebook: https://github.com/aws-samples/3P-Agentic-Frameworks/blob/426d79969e050ea6dba660f8af0e04efcd98d558/mcp-protocol/opensearch_mcp_server.ipynb

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
