### PR TITLE
fix terraform dependencies for eks dynamodb example

### DIFF
--- a/eks/terraform/dynamodb.tf
+++ b/eks/terraform/dynamodb.tf
@@ -1,15 +1,12 @@
-module "dynamodb_table" {
-  source = "terraform-aws-modules/dynamodb-table/aws"
+resource "aws_dynamodb_table" "main" {
+  name         = local.name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
 
-  name     = local.name
-  hash_key = "id"
-
-  attributes = [
-    {
-      name = "id"
-      type = "N"
-    }
-  ]
+  attribute {
+    name = "id"
+    type = "N"
+  }
 
   tags = local.tags
 }

--- a/eks/terraform/versions.tf
+++ b/eks/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.95.0, < 6.0.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
Fix problem with eks terraform dependencies problems

*Description of changes:*
Use simpler terraform to create dynamodb.
